### PR TITLE
 🖥 💻 📱

### DIFF
--- a/model.html
+++ b/model.html
@@ -2,10 +2,13 @@
 <html>
 <head>
 	<link rel="stylesheet" type="text/css" href="styles/index.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
+  <a class="edit-button" href="#edit">Edit &rarr;</a>
 	<style id="grid_style"></style>
 	<div id="grid_container">
+    <a id="grid_mobile_overlay" href="#grid"></a>
 		<div id="grid"></div>
 	</div>
 	<div id="play_container">

--- a/scripts/engine/Editor.js
+++ b/scripts/engine/Editor.js
@@ -224,7 +224,7 @@ Editor.createActionsUI = function(actionConfigs, dom){
 		// The actual action
 		var actionDOM = Editor.createActionUI(actionConfigs[i]);
 		entry.appendChild(actionDOM);
-		
+
 	}
 
 	// Add action?
@@ -232,7 +232,7 @@ Editor.createActionsUI = function(actionConfigs, dom){
 	var addAction = Editor.createActionAdder(actionConfigs, dom);
 	entry.appendChild(addAction);
 	list.appendChild(entry);
-	
+
 	// Return dom
 	return dom;
 
@@ -314,7 +314,7 @@ Editor.createSelector = function(keyValues, actionConfig, propName, options){
 
 	// Populate options: icon + name for each state, value is the ID.
 	for(var i=0;i<keyValues.length;i++){
-		
+
 		var keyValue = keyValues[i];
 
 		// Create option
@@ -335,7 +335,7 @@ Editor.createSelector = function(keyValues, actionConfig, propName, options){
 	select.oninput = function(){
 		actionConfig[propName] = select.value;
 	};
-	
+
 	// Return
 	return select;
 
@@ -353,7 +353,7 @@ Editor.createStateSelector = function(actionConfig, propName){
 		var stateConfigs = Model.data.states;
 		var selectedAnOption = false;
 		for(var i=0;i<stateConfigs.length;i++){
-			
+
 			var stateConfig = stateConfigs[i];
 
 			// Create option
@@ -396,7 +396,7 @@ Editor.createStateSelector = function(actionConfig, propName){
 		unsubscribe(_listener2);
 	});
 
-	
+
 	// Return
 	return select;
 
@@ -435,7 +435,7 @@ Editor.createNumber = function(actionConfig, propName, options){
 
 		// Message?
 		if(options.message) publish(options.message);
-		
+
 	};
 
 	// When move away, fix it.
@@ -516,16 +516,12 @@ Editor.createProportions = function(){
 			// Slider event
 			(function(proportion,slider,index){
 				slider.onmousedown = function(){
-					selectedIndex = index;
 					_createSnapshot();
 				};
 				slider.oninput = function(){
 					proportion.parts = parseFloat(slider.value);
-					_adjustAll();
+					_adjustAll(index);
 					Grid.reinitialize();
-				};
-				slider.onmouseup = function(){
-					selectedIndex = -1;
 				};
 			})(proportion,slider,i);
 
@@ -534,15 +530,14 @@ Editor.createProportions = function(){
 	_populate();
 
 	// Adjust 'em all dang it
-	var selectedIndex = -1;
 	var snapshot = [];
 	var _createSnapshot = function(){
 		snapshot = [];
 		for(var i=0;i<proportions.length;i++){
-			snapshot.push(proportions[i].parts); 
+			snapshot.push(proportions[i].parts);
 		}
 	};
-	var _adjustAll = function(){
+	var _adjustAll = function(selectedIndex){
 
 		// SPECIAL CASE: If there's just ONE proportion, set to 100 & disable it.
 		// DON'T DO ANYTHING ELSE.
@@ -565,7 +560,7 @@ Editor.createProportions = function(){
 		for(var i=0;i<snapshot.length;i++){
 			if(i!=selectedIndex) total+=snapshot[i];
 		}
-		
+
 		// EDGE CASE: If old total IS ZERO, bump everything else by one.
 		if(total==0){
 			for(var i=0;i<snapshot.length;i++){
@@ -624,7 +619,7 @@ Editor.createProportions = function(){
 /////////////////////////
 
 var EditorShortcuts = function(dom){
-	
+
 	var self = this;
 	self.dom = dom;
 

--- a/scripts/engine/UI.js
+++ b/scripts/engine/UI.js
@@ -4,7 +4,7 @@
 ///// PLAY CONTROLS /////
 /////////////////////////
 
-// RESET 
+// RESET
 var play_reset = document.getElementById("play_reset");
 play_reset.onclick = function(){
 	Grid.reinitialize();
@@ -66,7 +66,7 @@ Grid.dom.addEventListener("mousedown",function(event){
 Grid.dom.addEventListener("mousemove",function(event){
 
 	if(!Mouse.pressed) return;
-	
+
 	var pos = getMousePosition(event);
 
 	// New position
@@ -75,7 +75,7 @@ Grid.dom.addEventListener("mousemove",function(event){
 		Mouse.y = pos.y;
 		changeCell();
 	}
-	
+
 },false);
 window.addEventListener("mouseup",function(event){
 	Mouse.pressed = false;
@@ -103,5 +103,18 @@ var changeCell = function(){
 	publish("/grid/updateAgents");
 
 };
+
+// Edit mode toggle on mobile:
+function checkHash() {
+  if (window.location.hash === "#edit") {
+    document.body.className = "edit";
+  } else {
+    document.body.className = "";
+  }
+  if (Grid.array) publish("/grid/updateSize");
+}
+
+window.addEventListener("hashchange", checkHash, false);
+checkHash();
 
 })();

--- a/styles/index.css
+++ b/styles/index.css
@@ -63,6 +63,9 @@ THE EDITOR
 	height: 40px;
 	overflow: hidden;
 }
+#editor .editor_actions {
+  line-height: 2em;
+}
 #editor input[type=text], #editor input[type=number]{
 
 	font-family: Helvetica, Arial, sans-serif;
@@ -117,6 +120,7 @@ THE EDITOR
 	font-weight: 100;
 	font-size: 15px;
 
+  line-height: 1.2em;
 	text-align: center;
 	color: #aaa;
 }
@@ -169,6 +173,12 @@ THE EDITOR
 #editor select{
 	/*font-size: 50px;*/
 	max-width:120px;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  background: transparent;
+  border: 1px solid #aaa;
+  border-radius: 3px;
 }
 #editor ul{
 	padding-left: 30px;

--- a/styles/index.css
+++ b/styles/index.css
@@ -15,7 +15,7 @@ div{
 }
 
 /***************
-THE GRID 
+THE GRID
 ***************/
 
 #grid_container{
@@ -30,6 +30,7 @@ THE GRID
 	margin: auto;
 	top:0; left:0; right:0; bottom:0;
 	cursor: default;
+  z-index: 31;
 }
 #grid > div{
 }
@@ -38,14 +39,14 @@ THE GRID
 }
 
 /***************
-THE EDITOR 
+THE EDITOR
 ***************/
 
 #editor_container{
 	min-width: 340px;
 	width: 40%;
 	height:100%;
-	
+
 	position: absolute;
 	right: 0;
 
@@ -63,7 +64,7 @@ THE EDITOR
 	overflow: hidden;
 }
 #editor input[type=text], #editor input[type=number]{
-	
+
 	font-family: Helvetica, Arial, sans-serif;
 	font-weight: 100;
 
@@ -78,7 +79,7 @@ THE EDITOR
 	width:40px;
 	height:40px;
 	background: none;
-	border-right: none; 
+	border-right: none;
 	display: block;
 	float: left;
 
@@ -111,7 +112,7 @@ THE EDITOR
 	border:1px solid #aaa;
 	border-radius: 5px;
 	position: absolute;
-	
+
 	font-family: sans-serif;
 	font-weight: 100;
 	font-size: 15px;
@@ -130,7 +131,7 @@ THE EDITOR
 	width: 240px;
 	height: 40px;
 	background: #aaa;
-	
+
 	font-family: sans-serif;
 	font-weight: 100;
 	font-size: 20px;
@@ -227,7 +228,7 @@ THE EDITOR
 }
 
 /***************
-THE PLAY CONTROLS 
+THE PLAY CONTROLS
 ***************/
 
 #play_container{
@@ -236,21 +237,22 @@ THE PLAY CONTROLS
 	position: absolute;
 	left: 0;
 	bottom: 10px;
+  text-align: center;
 }
 #play_controls{
-	width: 240px;
 	height: 50px;
 	margin: 0 auto;
 	overflow: hidden;
 }
 #play_controls > div{
+  display: inline-block;
 	background: #ccc;
 	border-radius: 5px;
 	height: 30px;
 	cursor: pointer;
-	float: left;
 	color: #888;
 	padding: 10px;
+  margin-left: -0.3em;
 	text-align: center;
 	line-height: 30px;
 	font-weight: normal;
@@ -258,22 +260,22 @@ THE PLAY CONTROLS
 #play_controls > div:hover{
 	background: #ddd;
 }
-#play_controls > #play_reset{
+#play_reset{
 	width:40px;
 	margin-right: 10px;
 }
-#play_controls > #play_pause{
+#play_pause{
 	width:80px;
 	margin-right: 10px;
 }
-#play_controls > #play_pause[paused=true]{
+#play_pause[paused=true]{
 	background: #333;
 	color: #fff;
 }
-#play_controls > #play_pause[paused=true]:hover{
+#play_pause[paused=true]:hover{
 	background: #444;
 }
-#play_controls > #play_step{
+#play_step{
 	width:40px;
 }
 
@@ -300,7 +302,169 @@ HACK: SCROLLBARS
     background-color: rgba(0, 0, 0, .5);
 }
 
-.frame::-webkit-scrollbar-track { 
-    background-color: #fff; 
-    border-radius: 0px; 
-} 
+.frame::-webkit-scrollbar-track {
+    background-color: #fff;
+    border-radius: 0px;
+}
+
+/***************
+MOBILE LAYOUT
+***************/
+
+#grid_mobile_overlay,
+.edit-button {
+  display: none;
+}
+
+@media screen and (max-width: 850px) {
+  #grid_container {
+    width: 100%;
+  }
+
+  .edit #grid_container {
+    position: absolute;
+    width: 200px;
+    height: 200px;
+    bottom: 0;
+    right: 30px;
+    z-index: 30;
+    background: white;
+    padding: 15px;
+    border-radius: 15px;
+  }
+
+  .edit #grid_mobile_overlay {
+    display: block;
+    z-index: 32;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .edit-button {
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    border-bottom-left-radius: 5px;
+    background: #ccc;
+    padding: 10px;
+    color: #888;
+    text-decoration: none;
+    font-weight: normal;
+    z-index: 40;
+  }
+
+  .edit .edit-button {
+    display: none;
+  }
+
+  #play_container {
+    width: 100%;
+  }
+
+  .edit #play_container {
+    z-index: 20;
+    background: white;
+    width: auto;
+    left: 0;
+    right: 260px;
+    bottom: 0;
+    padding: 15px 0;
+  }
+
+  #editor_container {
+    display: none;
+  }
+
+  .edit #editor_container {
+    display: block;
+    min-width: 0;
+    width: 100%;
+    height: -webkit-calc(100% - 80px);
+    height:    -moz-calc(100% - 80px);
+    height:         calc(100% - 80px);
+    left: 0;
+    z-index: 10;
+  }
+
+  .edit #editor {
+    margin-bottom: 165px;
+  }
+}
+
+@media screen and (max-width: 550px) {
+  .edit #grid_container {
+    width: 150px;
+    height: 150px;
+    padding: 10px;
+    border-radius: 10px;
+  }
+
+  #play_container,
+  #play_controls {
+    height: 40px;
+  }
+
+  .edit #play_container {
+    right: 200px;
+    padding: 10px 0;
+  }
+
+  #play_controls > div {
+    padding: 5px 10px;
+  }
+
+  #play_pause,
+  #play_reset,
+  #play_step {
+    width: auto;
+  }
+
+  .edit #editor_container {
+    height: -webkit-calc(100% - 60px);
+    height:    -moz-calc(100% - 60px);
+    height:         calc(100% - 60px);
+  }
+
+  .edit #editor {
+    margin-bottom: 125px;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  .edit #grid_container {
+    width: 100px;
+    height: 100px;
+  }
+
+  .edit #play_container {
+    right: 150px;
+    height: auto;
+    padding-bottom: 0;
+  }
+
+  #play_controls {
+    height: auto;
+  }
+
+  #play_controls > div {
+    margin-bottom: 10px;
+  }
+
+  .edit #editor {
+    margin-bottom: 75px;
+  }
+}
+
+@media screen and (max-width: 350px) {
+  .edit #play_pause {
+    margin-right: 0;
+  }
+
+  .edit #play_step {
+    display: none;
+  }
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -20,7 +20,7 @@ THE GRID
 
 #grid_container{
 	width: 60%;
-	height: calc(100% - 70px);
+	height: calc(100vh - 70px);
 	float: left;
 	position: relative;
 }


### PR DESCRIPTION
Mobile layout! I had a train journey to kill, so now you can harass strangers by showing them emoji automata on the tiny glowing rectangle in your pocket?

Things are as they were at desktop/laptop sizes, but when you get down to phone size, we have two views:

The grid:
<img src="https://cloud.githubusercontent.com/assets/1489520/11154893/e7ae7972-8a39-11e5-963d-3cd4c0798904.png" width="360">

The editor, with a little preview grid:
<img src="https://cloud.githubusercontent.com/assets/1489520/11154894/e7b0770e-8a39-11e5-8c4b-d33903e2aa24.png" width="360">

On the grid view, tap 'Edit' to get to the editor. on the editor, tap the mini-grid or use the browsers back button to get back to the grid view.

Things to think about:
- This doesn't support the graph yet, but looking at some of the more recent models you've been using, the graph maybe makes less sense now? Graphs are fun though.
- The range inputs don't seem to work on my phone. I'll look into this and amend this PR when I have time
- Performance sucks. A lot. You could probably stick with a DOM renderer and get smarter about what to update when, but you'd probably be better off using canvas/webgl. 
- Emoji entry on platforms other than OSX. What's the equivalent of cmd-ctrl-space on a phone? Or a PC?

WOOP
